### PR TITLE
Upgrade Prometheus version from 1.5.2 to 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o docker-flow-monitor
 
 
 
-FROM prom/prometheus:v1.5.2
+FROM prom/prometheus:v1.8.1
 
 ENV GLOBAL_SCRAPE_INTERVAL=10s \
     ARG_CONFIG_FILE=/etc/prometheus/prometheus.yml \


### PR DESCRIPTION
In versions 1.6+ a new memory option was introduced

https://prometheus.io/docs/operating/storage/

> Prior to v1.6, there was no flag storage.local.target-heap-size. Instead, the number of chunks kept in memory had to be configured using the flags storage.local.memory-chunks and storage.local.max-chunks-to-persist. These flags still exist for compatibility reasons. However, storage.local.max-chunks-to-persist has no effect anymore, and if storage.local.memory-chunks is set to a non-zero value x, it is used to override the value for storage.local.target-heap-size to 3072*x.