### PR TITLE
Updating node exporter's command and default version

### DIFF
--- a/stacks/exporters-alert.yml
+++ b/stacks/exporters-alert.yml
@@ -39,7 +39,7 @@ services:
           memory: 50M
 
   node-exporter:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.13.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:

--- a/stacks/exporters-alert.yml
+++ b/stacks/exporters-alert.yml
@@ -65,7 +65,8 @@ services:
           memory: 20M
         limits:
           memory: 50M
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
+    
 
 networks:
   monitor:

--- a/stacks/exporters-aws.yml
+++ b/stacks/exporters-aws.yml
@@ -39,7 +39,7 @@ services:
           memory: 50M
 
   node-exporter-manager:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.14.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:
@@ -76,7 +76,7 @@ services:
     command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
   node-exporter-worker:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.14.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:

--- a/stacks/exporters-aws.yml
+++ b/stacks/exporters-aws.yml
@@ -73,7 +73,7 @@ services:
           memory: 30M
         limits:
           memory: 50M
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
   node-exporter-worker:
     image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.14.0}
@@ -112,7 +112,7 @@ services:
           memory: 30M
         limits:
           memory: 50M
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
 networks:
   monitor:

--- a/stacks/exporters-mem.yml
+++ b/stacks/exporters-mem.yml
@@ -39,7 +39,7 @@ services:
           memory: 50M
 
   node-exporter:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.13.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:

--- a/stacks/exporters-mem.yml
+++ b/stacks/exporters-mem.yml
@@ -59,7 +59,7 @@ services:
           memory: 20M
         limits:
           memory: 50M
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
 networks:
   monitor:

--- a/stacks/exporters-tutorial.yml
+++ b/stacks/exporters-tutorial.yml
@@ -37,7 +37,7 @@ services:
         - com.df.alertIf.1=(sum by (instance) (node_memory_MemTotal) - sum by (instance) (node_memory_MemFree + node_memory_Buffers + node_memory_Cached)) / sum by (instance) (node_memory_MemTotal) > 0.8
         - com.df.alertName.2=diskload
         - com.df.alertIf.2=@node_fs_limit:0.8
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
 networks:
   monitor:

--- a/stacks/exporters-with-labels.yml
+++ b/stacks/exporters-with-labels.yml
@@ -48,7 +48,7 @@ services:
         - com.df.alertIf.1=(sum by (instance) (node_memory_MemTotal) - sum by (instance) (node_memory_MemFree + node_memory_Buffers + node_memory_Cached)) / sum by (instance) (node_memory_MemTotal) > 0.8
         - com.df.alertName.2=diskload
         - com.df.alertIf.2=(node_filesystem_size{fstype="aufs"} - node_filesystem_free{fstype="aufs"}) / node_filesystem_size{fstype="aufs"} > 0.8
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
 networks:
   monitor:

--- a/stacks/exporters-with-labels.yml
+++ b/stacks/exporters-with-labels.yml
@@ -29,7 +29,7 @@ services:
         - com.df.scrapePort=8080
 
   node-exporter:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.13.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:

--- a/stacks/exporters.yml
+++ b/stacks/exporters.yml
@@ -44,7 +44,7 @@ services:
       labels:
         - com.df.notify=true
         - com.df.scrapePort=9100
-    command: '-collector.procfs /host/proc -collector.sysfs /host/sys -collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($$|/)" -collector.textfile.directory /etc/node-exporter/ -collectors.enabled="conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,stat,textfile,time,vmstat,ipvs"'
+    command: '--path.procfs="/host/proc" --path.sysfs="/host/sys" --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)" --collector.textfile.directory="/etc/node-exporter/" --collector.conntrack --collector.diskstats --collector.entropy --collector.filefd --collector.filesystem --collector.loadavg --collector.mdadm --collector.meminfo --collector.netdev --collector.netstat --collector.stat --collector.textfile --collector.time --collector.vmstat --collector.ipvs'
 
 networks:
   monitor:

--- a/stacks/exporters.yml
+++ b/stacks/exporters.yml
@@ -29,7 +29,7 @@ services:
         - com.df.scrapePort=8080
 
   node-exporter:
-    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.13.0}
+    image: basi/node-exporter:${NODE_EXPORTER_TAG:-v1.15.0}
     networks:
       - monitor
     environment:


### PR DESCRIPTION
The latest version that is used as default in the tutorial no longer works with the command.
This is due to a change in the node exporter, that is supported by the basi/node-exporter as of version v1.15.0. 

The tutorial currently works fine, will check others to be sure.
Already making the PR so it is easier to share the load of testing the versions with others.