### PR TITLE
Refactors Alertif shortcuts to use templates

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,17 +1,18 @@
 package server
 
 import (
-	"../prometheus"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"../prometheus"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
 )
 
 type ServerTestSuite struct {


### PR DESCRIPTION
1. Refactors Alertif shortcuts to use templates
2. Converts `alertIfShortcutData` to `map[string]alertIfShortcut`
3. `go fmt` places first party imports before third party imports

The `Values` parameter in the templates are always slices, thus the old `[VALUE]` placeholder becomes `[VALUE_0]`.