### PR TITLE
Fix remote configuration

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -43,10 +43,10 @@ func WriteConfig(scrapes map[string]Scrape, alerts map[string]Alert) {
 // GetRemoteConfig returns remote_write and remote_read configs
 func GetRemoteConfig() string {
 	rw := getDataFromEnvVars("REMOTE_WRITE")
-	config := getConfigSection("remote_write", rw)
+	config := getConfigSectionArray("remote_write", rw)
 
 	rr := getDataFromEnvVars("REMOTE_READ")
-	config += getConfigSection("remote_read", rr)
+	config += getConfigSectionArray("remote_read", rr)
 
 	return config
 }
@@ -185,6 +185,23 @@ func getConfigSection(section string, data map[string]map[string]string) string 
 			config += "\n  " + key + ":"
 			for subKey, value := range values {
 				config += "\n    " + subKey + ": " + value
+			}
+		}
+	}
+	return config
+}
+
+func getConfigSectionArray(section string, data map[string]map[string]string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	config := fmt.Sprintf(`%s:`, section)
+	for key, values := range data {
+		if len(values[""]) > 0 {
+			if config == fmt.Sprintf(`%s:`, section) {
+				config += "\n  - " + key + ": " + values[""]
+			} else {
+				config += "\n    " + key + ": " + values[""]
 			}
 		}
 	}

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -50,23 +50,39 @@ func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsEmptyString_WhenEnvVarsAre
 }
 
 func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsRemoteWriteUrl() {
-	defer func() { os.Unsetenv("REMOTE_WRITE_URL") }()
+	defer func() {
+		os.Unsetenv("REMOTE_WRITE_URL")
+		os.Unsetenv("REMOTE_WRITE_REMOTE_TIMEOUT")
+	}()
 	os.Setenv("REMOTE_WRITE_URL", "http://acme.com/write")
-	expected := `remote_write:
-  url: http://acme.com/write`
+	os.Setenv("REMOTE_WRITE_REMOTE_TIMEOUT", "30s")
+	expected_1 := `remote_write:
+  - url: http://acme.com/write
+    remote_timeout: 30s`
+	expected_2 := `remote_write:
+  - remote_timeout: 30s
+    url: http://acme.com/write`
 	actual := GetRemoteConfig()
 
-	s.Equal(expected, actual)
+	s.Contains([]string{expected_1, expected_2}, actual)
 }
 
 func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsRemoteReadUrl() {
-	defer func() { os.Unsetenv("REMOTE_READ_URL") }()
+	defer func() {
+		os.Unsetenv("REMOTE_READ_URL")
+		os.Unsetenv("REMOTE_READ_REMOTE_TIMEOUT")
+	}()
 	os.Setenv("REMOTE_READ_URL", "http://acme.com/read")
-	expected := `remote_read:
-  url: http://acme.com/read`
+	os.Setenv("REMOTE_READ_REMOTE_TIMEOUT", "30s")
+	expected_1 := `remote_read:
+  - url: http://acme.com/read
+    remote_timeout: 30s`
+	expected_2 := `remote_read:
+  - remote_timeout: 30s
+    url: http://acme.com/read`
 	actual := GetRemoteConfig()
 
-	s.Equal(expected, actual)
+	s.Contains([]string{expected_1, expected_2}, actual)
 }
 
 // GetGlobalConfig


### PR DESCRIPTION
Fixes config bug with `remote_write` and `remote_read`. The configuration options should be an array of dictionaries. For reference: https://github.com/prometheus/prometheus/blob/release-2.0/config/testdata/conf.good.yml#L16