### PR TITLE
Adds flexible env configuration options

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -5,211 +5,322 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
 )
 
-// WriteConfig creates Prometheus configuration (`/etc/prometheus/prometheus.yml`) and rules (`/etc/prometheus/alert.rules`) files.
-func WriteConfig(scrapes map[string]Scrape, alerts map[string]Alert) {
-	FS.MkdirAll("/etc/prometheus", 0755)
-	gc := GetGlobalConfig()
-	sc := GetScrapeConfig(scrapes)
-	rc := GetRemoteConfig()
-	amc := GetAlertManagerConfig()
-	ruleFiles := ""
+// WriteConfig creates Prometheus configuration at configPath and writes alerts into /etc/prometheus/alert.rules
+func WriteConfig(configPath string, scrapes map[string]Scrape, alerts map[string]Alert) {
+	c := &Config{}
+
+	configDir := filepath.Dir(configPath)
+	FS.MkdirAll(configDir, 0755)
+	c.InsertScrapes(scrapes)
+
 	if len(alerts) > 0 {
 		logPrintf("Writing to alert.rules")
-		ruleFiles = "rule_files:\n  - 'alert.rules'"
 		afero.WriteFile(FS, "/etc/prometheus/alert.rules", []byte(GetAlertConfig(alerts)), 0644)
+		c.RuleFiles = []string{"alert.rules"}
 	}
 
-	config := ""
-	for _, c := range []string{gc, sc, rc, ruleFiles, amc} {
-		if len(c) > 0 {
-			if len(config) == 0 {
-				config = c
-			} else {
-				config += "\n" + c
+	alertmanagerURL := os.Getenv("ARG_ALERTMANAGER_URL")
+	if len(alertmanagerURL) != 0 {
+		if err := c.InsertAlertManagerURL(alertmanagerURL); err != nil {
+			logPrintf("Unable to insert alertmanager url %s into prometheus config", alertmanagerURL)
+		}
+	}
+
+	for _, e := range os.Environ() {
+		envSplit := strings.SplitN(e, "=", 2)
+		if len(envSplit) != 2 {
+			continue
+		}
+		key, value := envSplit[0], envSplit[1]
+
+		if strings.HasPrefix(key, "GLOBAL_") ||
+			strings.HasPrefix(key, "ALERTING_") ||
+			strings.HasPrefix(key, "SCRAPE_CONFIGS_") ||
+			strings.HasPrefix(key, "REMOTE_WRITE_") ||
+			strings.HasPrefix(key, "REMOTE_READ_") {
+			if err := c.InsertEnv(key, value); err != nil {
+				logPrintf("Unable to insert %s into prometheus config", e)
 			}
 		}
 	}
 
 	logPrintf("Writing to prometheus.yml")
-	afero.WriteFile(FS, "/etc/prometheus/prometheus.yml", []byte(config), 0644)
+	configYAML, _ := yaml.Marshal(c)
+	afero.WriteFile(FS, configPath, configYAML, 0644)
+
 }
 
-// GetRemoteConfig returns remote_write and remote_read configs
-func GetRemoteConfig() string {
-	rw := getDataFromEnvVars("REMOTE_WRITE")
-	config := getConfigSectionArray("remote_write", rw)
-
-	rr := getDataFromEnvVars("REMOTE_READ")
-	if rrc := getConfigSectionArray("remote_read", rr); len(rrc) != 0 {
-		if len(config) == 0 {
-			config = rrc
-		} else {
-			config += "\n" + rrc
-		}
-	}
-
-	return config
+// InsertEnv inserts envKey/envValue into config
+func (c *Config) InsertEnv(envKey string, envValue string) error {
+	envKey, envValue = convertToV2Env(envKey, envValue)
+	envKey = strings.ToLower(envKey)
+	obj := reflect.ValueOf(c)
+	location := strings.Split(envKey, "__")
+	return insertWithLocation(obj, location, envValue, 0)
 }
 
-// GetGlobalConfig returns global section of the configuration
-func GetGlobalConfig() string {
-	data := getDataFromEnvVars("GLOBAL")
-	return getConfigSection("global", data)
-}
-
-// GetAlertManagerConfig returns alerting section of the configuration
-func GetAlertManagerConfig() string {
-	alertmanagerURL := os.Getenv("ARG_ALERTMANAGER_URL")
-	url, err := url.Parse(alertmanagerURL)
+// InsertAlertManagerURL inserts alert into config
+func (c *Config) InsertAlertManagerURL(alertURL string) error {
+	url, err := url.Parse(alertURL)
 	if err != nil {
-		return ""
+		return fmt.Errorf("Unable to parse url %s", alertURL)
 	}
-	templateStr := `alerting:
-  alertmanagers:
-  - scheme: {{ .Scheme }}
-    static_configs:
-    - targets:
-      - {{ .Host }}`
-	tmpl, _ := template.New("").Parse(templateStr)
 
-	b := new(bytes.Buffer)
-	tmpl.Execute(b, url)
-	return b.String()
+	amc := &AlertmanagerConfig{
+		Scheme: url.Scheme,
+		ServiceDiscoveryConfig: ServiceDiscoveryConfig{
+			StaticConfigs: []*TargetGroup{&TargetGroup{
+				Targets: []string{url.Host},
+			}},
+		},
+	}
 
+	c.AlertingConfig.AlertmanagerConfigs = append(c.AlertingConfig.AlertmanagerConfigs, amc)
+	return nil
 }
 
-// GetScrapeConfig returns scrapes section of the configuration
-func GetScrapeConfig(scrapes map[string]Scrape) string {
-	config := getScrapeConfigFromMap(scrapes)
+// InsertScrapes inserts scrapes into config
+func (c *Config) InsertScrapes(scrapes map[string]Scrape) {
 
-	if dirConfig := getScrapeConfigFromDir(); len(dirConfig) > 0 {
-		if len(config) == 0 {
-			config = dirConfig
+	for _, s := range scrapes {
+		var newScrape *ScrapeConfig
+		metricsPath := s.MetricsPath
+		if len(metricsPath) == 0 {
+			metricsPath = "/metrics"
+		}
+		if s.ScrapeType == "static_configs" {
+			newScrape = &ScrapeConfig{
+				ServiceDiscoveryConfig: ServiceDiscoveryConfig{
+					StaticConfigs: []*TargetGroup{&TargetGroup{
+						Targets: []string{fmt.Sprintf("%s:%d", s.ServiceName, s.ScrapePort)},
+					}},
+				},
+				JobName:     s.ServiceName,
+				MetricsPath: metricsPath,
+			}
 		} else {
-			config += "\n" + dirConfig
+			newScrape = &ScrapeConfig{
+				ServiceDiscoveryConfig: ServiceDiscoveryConfig{
+					DNSSDConfigs: []*DNSSDConfig{&DNSSDConfig{
+						Names: []string{fmt.Sprintf("tasks.%s", s.ServiceName)},
+						Port:  s.ScrapePort,
+						Type:  "A",
+					}},
+				},
+				JobName:     s.ServiceName,
+				MetricsPath: metricsPath,
+			}
 		}
+		c.ScrapeConfigs = append(c.ScrapeConfigs, newScrape)
 	}
-
-	if len(config) > 0 {
-		config = fmt.Sprintf("scrape_configs:\n%s", config)
-	}
-	return config
 }
 
-func getDataFromEnvVars(prefix string) map[string]map[string]string {
-	data := map[string]map[string]string{}
-	for _, e := range os.Environ() {
-		if key, value := getArgFromEnv(e, prefix); len(key) > 0 {
-			realKey := key
-			subKey := ""
-			if strings.Contains(key, "-") {
-				keys := strings.Split(key, "-")
-				realKey = keys[0]
-				subKey = keys[1]
-			}
-			if _, ok := data[realKey]; !ok {
-				data[realKey] = map[string]string{}
-			}
-			subData := data[realKey]
-			subData[subKey] = value
-		}
-	}
-	return data
-}
-
-func getScrapeConfigFromDir() string {
-	dir := "/run/secrets/"
-	if len(os.Getenv("CONFIGS_DIR")) > 0 {
-		dir = os.Getenv("CONFIGS_DIR")
-	}
+// InsertScrapesFromDir inserts scrapes from directory
+func (c *Config) InsertScrapesFromDir(dir string) {
 	if !strings.HasSuffix(dir, "/") {
 		dir += "/"
 	}
-
-	config := ""
 	if files, err := afero.ReadDir(FS, dir); err == nil {
 		for _, file := range files {
 			if !strings.HasPrefix(file.Name(), "scrape_") {
 				continue
 			}
 			if content, err := afero.ReadFile(FS, dir+file.Name()); err == nil {
-				contentStr := string(content)
-				if len(contentStr) > 0 {
-					if len(config) > 0 {
-						config += "\n" + contentStr
-					} else {
-						config = contentStr
-					}
+				sc := []*ScrapeConfig{}
+
+				// Trim for backwards compability
+				content = normalizeScrapeFile(content)
+				err := yaml.Unmarshal(content, &sc)
+				if err != nil {
+					continue
 				}
-
+				c.ScrapeConfigs = append(c.ScrapeConfigs, sc[0])
 			}
 		}
+
 	}
-	return config
+
 }
 
-func getScrapeConfigFromMap(scrapes map[string]Scrape) string {
-	if len(scrapes) != 0 {
-		templateString := `
-{{- range . }}
-  - job_name: "{{.ServiceName}}"
-    metrics_path: {{if .MetricsPath}}{{.MetricsPath}}{{else}}/metrics{{end}}
-{{- if .ScrapeType }}
-    {{.ScrapeType}}:
-      - targets:
-        - {{.ServiceName}}:{{- .ScrapePort}}
-{{- else }}
-    dns_sd_configs:
-      - names: ["tasks.{{.ServiceName}}"]
-        type: A
-        port: {{.ScrapePort}}{{end}}
-{{- end}}`
-		tmpl, _ := template.New("").Parse(templateString)
-		var b bytes.Buffer
-		tmpl.Execute(&b, scrapes)
-		return strings.TrimPrefix(b.String(), "\n")
-
-	}
-	return ""
-}
-
-func getConfigSection(section string, data map[string]map[string]string) string {
-	if len(data) == 0 {
-		return ""
-	}
-	config := fmt.Sprintf(`%s:`, section)
-	for key, values := range data {
-		if len(values[""]) > 0 {
-			config += "\n  " + key + ": " + values[""]
-		} else {
-			config += "\n  " + key + ":"
-			for subKey, value := range values {
-				config += "\n    " + subKey + ": " + value
-			}
+func normalizeScrapeFile(content []byte) []byte {
+	spaceCnt := 0
+	for i, c := range content {
+		if c != ' ' {
+			spaceCnt = i
+			break
 		}
 	}
-	return config
+	bf := new(bytes.Buffer)
+	bf.WriteByte('\n')
+	for i := 0; i < spaceCnt; i++ {
+		bf.WriteByte(' ')
+	}
+	content = bytes.TrimLeft(content, " ")
+	return bytes.Replace(content, bf.Bytes(), []byte{'\n'}, -1)
 }
 
-func getConfigSectionArray(section string, data map[string]map[string]string) string {
-	if len(data) == 0 {
-		return ""
+func convertToV2Env(envKey string, envValue string) (string, string) {
+	if strings.Contains(envKey, "__") {
+		return envKey, envValue
 	}
-	config := fmt.Sprintf(`%s:`, section)
-	for key, values := range data {
-		if len(values[""]) > 0 {
-			if config == fmt.Sprintf(`%s:`, section) {
-				config += "\n  - " + key + ": " + values[""]
-			} else {
-				config += "\n    " + key + ": " + values[""]
-			}
+
+	envKey = strings.Replace(envKey, "GLOBAL_", "GLOBAL__", 1)
+	envKey = strings.Replace(envKey, "REMOTE_WRITE_", "REMOTE_WRITE_1__", 1)
+	envKey = strings.Replace(envKey, "REMOTE_READ_", "REMOTE_READ_1__", 1)
+
+	if strings.HasPrefix(envKey, "GLOBAL__EXTERNAL_LABELS") {
+		envSplit := strings.Split(envKey, "-")
+		if len(envSplit) == 2 {
+			envKey = envSplit[0]
+			envValue = fmt.Sprintf("%s=%s", strings.ToLower(envSplit[1]), envValue)
 		}
 	}
-	return config
+	return envKey, envValue
+}
+
+var sliceRegex = regexp.MustCompile("^(.+)_(\\d+)$")
+
+func insertWithLocation(obj reflect.Value, location []string, value string, index int) error {
+	switch obj.Kind() {
+	case reflect.Ptr:
+		if obj.IsNil() {
+			newObj := reflect.New(obj.Type().Elem())
+			obj.Set(newObj)
+		}
+		objElem := obj.Elem()
+		return insertWithLocation(objElem, location, value, index)
+	case reflect.Struct:
+		t := reflect.TypeOf(obj.Interface())
+		if index >= len(location) {
+			return fmt.Errorf("incorrect env location")
+		}
+		targetTag := location[index]
+		for i := 0; i < t.NumField(); i++ {
+			tField := t.Field(i)
+			tags := tField.Tag.Get("yaml")
+			tagsSplit := strings.Split(tags, ",")
+			tag := tagsSplit[0]
+
+			// struct or primitive
+			if targetTag == tag {
+				v := obj.Field(i)
+				return insertWithLocation(v, location, value, index+1)
+			}
+
+			// slice
+			rootTagR := sliceRegex.FindAllStringSubmatch(targetTag, 1)
+			if len(rootTagR) == 1 && len(rootTagR[0]) == 3 {
+				rootTag := rootTagR[0][1]
+				if rootTag == tag {
+					v := obj.Field(i)
+					return insertWithLocation(v, location, value, index)
+				}
+			}
+
+			// inline struct (always last element)
+			if tagsSplit[len(tagsSplit)-1] == "inline" {
+				v := obj.Field(i)
+				err := insertWithLocation(v, location, value, index)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		return fmt.Errorf("Unable to find tag: %s", targetTag)
+	case reflect.Slice:
+		if index >= len(location) {
+			return fmt.Errorf("Incorrect env location")
+		}
+		targetTag := location[index]
+		sliceTag := sliceRegex.FindAllStringSubmatch(targetTag, 1)
+		if len(sliceTag) == 0 || len(sliceTag[0]) != 3 {
+			return fmt.Errorf("Array tag must be of the form: label_NUM")
+		}
+		indexValue, err := strconv.Atoi(sliceTag[0][2])
+		if err != nil {
+			return fmt.Errorf("Array tag must end with a number")
+		}
+		if obj.Len() < indexValue {
+			newVP := reflect.New(obj.Type()).Elem()
+			newVP.Set(reflect.MakeSlice(obj.Type(), indexValue, indexValue))
+			reflect.Copy(newVP, obj)
+			obj.Set(newVP)
+		}
+		return insertWithLocation(obj.Index(indexValue-1), location, value, index+1)
+	case reflect.Map:
+		// All Maps are map[string]string or map[string][]string
+		keyValue := strings.Split(value, "=")
+		if len(keyValue) != 2 {
+			return fmt.Errorf("Value for map must be of the form: key=value")
+		}
+		if obj.IsNil() {
+			obj.Set(reflect.MakeMap(obj.Type()))
+		}
+
+		// handle map[string][]string
+		key := keyValue[0]
+		sliceTag := sliceRegex.FindAllStringSubmatch(key, 1)
+		if len(sliceTag) == 1 && len(sliceTag[0]) == 3 {
+			location = append(location, sliceTag[0][0])
+			key = sliceTag[0][1]
+		}
+
+		newV := reflect.New(obj.Type().Elem()).Elem()
+
+		if newV.Kind() == reflect.Slice {
+			previousV := obj.MapIndex(reflect.ValueOf(key))
+			if previousV.IsValid() {
+				pLen := previousV.Len()
+				newV.Set(reflect.MakeSlice(obj.Type().Elem(), pLen, pLen))
+				reflect.Copy(newV, previousV)
+			}
+		}
+
+		err := insertWithLocation(newV, location, keyValue[1], index)
+		if err != nil {
+			return err
+		}
+		obj.SetMapIndex(reflect.ValueOf(key), newV)
+	default:
+		objI := obj.Interface()
+		switch objI.(type) {
+		case string:
+			obj.SetString(value)
+		case bool:
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("Non bool value")
+			}
+			obj.Set(reflect.ValueOf(v))
+		case int:
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("Non int value")
+			}
+			obj.Set(reflect.ValueOf(v))
+		case uint64:
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("Non int value")
+			}
+			obj.Set(reflect.ValueOf(uint64(v)))
+		case uint:
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("Non int value")
+			}
+			obj.Set(reflect.ValueOf(uint(v)))
+		}
+	}
+	return nil
 }

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -7,264 +7,496 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
+
+	"gopkg.in/yaml.v2"
 )
 
 type ConfigTestSuite struct {
 	suite.Suite
 }
 
-func (s *ConfigTestSuite) SetupTest() {
-}
-
 func TestConfigUnitTestSuite(t *testing.T) {
-	s := new(ConfigTestSuite)
-	logPrintlnOrig := logPrintf
-	os.Setenv("ARG_ALERTMANAGER_URL", "http://alert-manager:9093")
-	defer func() {
-		logPrintf = logPrintlnOrig
-		os.Unsetenv("ARG_ALERTMANAGER_URL")
-	}()
-	logPrintf = func(format string, v ...interface{}) {}
-	suite.Run(t, s)
+	suite.Run(t, new(ConfigTestSuite))
 }
 
-// GetAlertManagerConfig
+func (s *ConfigTestSuite) Test_RuleFiles() {
+	c := new(Config)
+	c.InsertEnv("RULE_FILES_1", "one_rule")
+	c.InsertEnv("RULE_FILES_2", "two_rule")
 
-func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsAlertManagerTarget() {
-	expected := `alerting:
-  alertmanagers:
-  - scheme: http
-    static_configs:
-    - targets:
-      - alert-manager:9093`
-	actual := GetAlertManagerConfig()
-	s.Equal(expected, actual)
+	s.Len(c.RuleFiles, 2)
+	s.Equal(c.RuleFiles[0], "one_rule")
+	s.Equal(c.RuleFiles[1], "two_rule")
 }
 
-// GetRemoteConfig
+func (s *ConfigTestSuite) Test_GlobalConfig() {
+	c := new(Config)
+	c.InsertEnv("GLOBAL__SCRAPE_INTERVAL", "20s")
+	c.InsertEnv("GLOBAL__SCRAPE_TIMEOUT", "10s")
+	c.InsertEnv("GLOBAL__EVALUATION_INTERVAL", "15s")
+	c.InsertEnv("GLOBAL__EXTERNAL_LABELS", "akey=avalue")
+	c.InsertEnv("GLOBAL__EXTERNAL_LABELS", "bkey=bvalue")
 
-func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsEmptyString_WhenEnvVarsAreNotSet() {
-	actual := GetRemoteConfig()
-
-	s.Empty(actual)
+	s.Equal("20s", c.GlobalConfig.ScrapeInterval)
+	s.Equal("10s", c.GlobalConfig.ScrapeTimeout)
+	s.Equal("15s", c.GlobalConfig.EvaluationInterval)
+	s.Equal("avalue", c.GlobalConfig.ExternalLabels["akey"])
+	s.Equal("bvalue", c.GlobalConfig.ExternalLabels["bkey"])
 }
 
-func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsRemoteWriteUrl() {
-	defer func() {
-		os.Unsetenv("REMOTE_WRITE_URL")
-		os.Unsetenv("REMOTE_WRITE_REMOTE_TIMEOUT")
-	}()
-	os.Setenv("REMOTE_WRITE_URL", "http://acme.com/write")
-	os.Setenv("REMOTE_WRITE_REMOTE_TIMEOUT", "30s")
-	expected1 := `remote_write:
-  - url: http://acme.com/write
-    remote_timeout: 30s`
-	expected2 := `remote_write:
-  - remote_timeout: 30s
-    url: http://acme.com/write`
-	actual := GetRemoteConfig()
+func (s *ConfigTestSuite) Test_AlertConfig() {
+	c := new(Config)
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__SOURCE_LABELS_1", "sourcelabel1")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__SOURCE_LABELS_2", "sourcelabel2")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__SEPARATOR", ",")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__REGEX", "regex")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__MODULUS", "10")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__TARGET_LABEL", "atarget")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__REPLACEMENT", "areplacement")
+	c.InsertEnv("ALERTING__ALERT_RELABEL_CONFIGS_1__ACTION", "anaction")
 
-	s.Contains([]string{expected1, expected2}, actual)
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__SCHEME", "http")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__PATH_PREFIX", "/hello1")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__TIMEOUT", "10s")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__RELABEL_CONFIGS_1__TARGET_LABEL", "what")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__STATIC_CONFIGS_1__TARGETS_1", "target1")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__STATIC_CONFIGS_1__TARGETS_2", "target2")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__STATIC_CONFIGS_1__LABELS", "label1=value1")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__STATIC_CONFIGS_1__LABELS", "label2=value2")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_1__STATIC_CONFIGS_1__SOURCE", "asource")
+
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__SCHEME", "https")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__PATH_PREFIX", "/hello2")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__TIMEOUT", "15s")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__RELABEL_CONFIGS_1__TARGET_LABEL", "what1")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__RELABEL_CONFIGS_2__TARGET_LABEL", "what2")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_1__NAMES_1", "name1")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_1__NAMES_2", "name2")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_1__REFRESH_INTERVAL", "24s")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_1__TYPE", "A")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_1__PORT", "1234")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_2__NAMES_1", "name3")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_2__NAMES_2", "name4")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_2__REFRESH_INTERVAL", "29s")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_2__TYPE", "A")
+	c.InsertEnv("ALERTING__ALERTMANAGERS_2__DNS_SD_CONFIGS_2__PORT", "234")
+
+	s.Require().Len(c.AlertingConfig.AlertRelabelConfigs, 1)
+	arc := c.AlertingConfig.AlertRelabelConfigs[0]
+	s.Require().Len(arc.SourceLabels, 2)
+	s.Equal("sourcelabel1", arc.SourceLabels[0])
+	s.Equal("sourcelabel2", arc.SourceLabels[1])
+	s.Equal(",", arc.Separator)
+	s.Equal("regex", arc.Regex)
+	s.Equal(uint64(10), arc.Modulus)
+	s.Equal("atarget", arc.TargetLabel)
+	s.Equal("areplacement", arc.Replacement)
+	s.Equal("anaction", arc.Action)
+
+	s.Require().Len(c.AlertingConfig.AlertmanagerConfigs, 2)
+	am1 := c.AlertingConfig.AlertmanagerConfigs[0]
+	s.Equal(am1.Scheme, "http")
+	s.Equal(am1.PathPrefix, "/hello1")
+	s.Equal("10s", am1.Timeout)
+
+	s.Require().Len(am1.RelabelConfigs, 1)
+	s.Equal("what", am1.RelabelConfigs[0].TargetLabel)
+	s.Require().Len(am1.ServiceDiscoveryConfig.StaticConfigs, 1)
+	sc1 := am1.ServiceDiscoveryConfig.StaticConfigs[0]
+	s.Require().Len(sc1.Targets, 2)
+	s.Equal("target1", sc1.Targets[0])
+	s.Equal("target2", sc1.Targets[1])
+	s.Equal("value1", sc1.Labels["label1"])
+	s.Equal("value2", sc1.Labels["label2"])
+	s.Equal("asource", sc1.Source)
+
+	am2 := c.AlertingConfig.AlertmanagerConfigs[1]
+	s.Equal("https", am2.Scheme)
+	s.Equal("/hello2", am2.PathPrefix)
+	s.Equal("15s", am2.Timeout)
+
+	s.Require().Len(am2.RelabelConfigs, 2)
+	s.Equal("what1", am2.RelabelConfigs[0].TargetLabel)
+	s.Equal("what2", am2.RelabelConfigs[1].TargetLabel)
+
+	s.Require().Len(am2.ServiceDiscoveryConfig.DNSSDConfigs, 2)
+	dnsc1 := am2.ServiceDiscoveryConfig.DNSSDConfigs[0]
+	s.Require().Len(dnsc1.Names, 2)
+	s.Equal("name1", dnsc1.Names[0])
+	s.Equal("name2", dnsc1.Names[1])
+	s.Equal("24s", dnsc1.RefreshInterval)
+	s.Equal("A", dnsc1.Type)
+	s.Equal(1234, dnsc1.Port)
+
+	dnsc2 := am2.ServiceDiscoveryConfig.DNSSDConfigs[1]
+	s.Require().Len(dnsc2.Names, 2)
+	s.Equal("name3", dnsc2.Names[0])
+	s.Equal("name4", dnsc2.Names[1])
+	s.Equal("29s", dnsc2.RefreshInterval)
+	s.Equal("A", dnsc2.Type)
+	s.Equal(234, dnsc2.Port)
+
 }
 
-func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsRemoteReadUrl() {
-	defer func() {
-		os.Unsetenv("REMOTE_READ_URL")
-		os.Unsetenv("REMOTE_READ_REMOTE_TIMEOUT")
-	}()
-	os.Setenv("REMOTE_READ_URL", "http://acme.com/read")
-	os.Setenv("REMOTE_READ_REMOTE_TIMEOUT", "30s")
-	expected1 := `remote_read:
-  - url: http://acme.com/read
-    remote_timeout: 30s`
-	expected2 := `remote_read:
-  - remote_timeout: 30s
-    url: http://acme.com/read`
-	actual := GetRemoteConfig()
+func (s *ConfigTestSuite) Test_ScrapeConfigs() {
+	c := &Config{}
 
-	s.Contains([]string{expected1, expected2}, actual)
+	c.InsertEnv("SCRAPE_CONFIGS_1__JOB_NAME", "jobname1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__HONOR_LABELS", "true")
+	c.InsertEnv("SCRAPE_CONFIGS_1__PARAMS", "key_1=first")
+	c.InsertEnv("SCRAPE_CONFIGS_1__PARAMS", "key_2=second")
+	c.InsertEnv("SCRAPE_CONFIGS_1__SCRAPE_INTERVAL", "13s")
+	c.InsertEnv("SCRAPE_CONFIGS_1__SCRAPE_TIMEOUT", "17s")
+	c.InsertEnv("SCRAPE_CONFIGS_1__METRICS_PATH", "/metrics1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__SCHEME", "http")
+	c.InsertEnv("SCRAPE_CONFIGS_1__SAMPLE_LIMIT", "10")
+	c.InsertEnv("SCRAPE_CONFIGS_1__DNS_SD_CONFIGS_1__NAMES_1", "hello")
+	c.InsertEnv("SCRAPE_CONFIGS_1__DNS_SD_CONFIGS_1__REFRESH_INTERVAL", "18s")
+	c.InsertEnv("SCRAPE_CONFIGS_1__DNS_SD_CONFIGS_1__TYPE", "A")
+	c.InsertEnv("SCRAPE_CONFIGS_1__DNS_SD_CONFIGS_1__PORT", "123")
+	c.InsertEnv("SCRAPE_CONFIGS_1__BASIC_AUTH__USERNAME", "username1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__BASIC_AUTH__PASSWORD", "password1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__BEARER_TOKEN", "btoken")
+	c.InsertEnv("SCRAPE_CONFIGS_1__PROXY_URL", "localhost1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__TLS_CONFIG__CA_FILE", "cafile")
+	c.InsertEnv("SCRAPE_CONFIGS_1__TLS_CONFIG__CERT_FILE", "certfile")
+	c.InsertEnv("SCRAPE_CONFIGS_1__TLS_CONFIG__KEY_FILE", "keyfile")
+	c.InsertEnv("SCRAPE_CONFIGS_1__TLS_CONFIG__SERVER_NAME", "servicename")
+	c.InsertEnv("SCRAPE_CONFIGS_1__TLS_CONFIG__INSECURE_SKIP_VERIFY", "true")
+	c.InsertEnv("SCRAPE_CONFIGS_1__RELABEL_CONFIGS_1__TARGET_LABEL", "target1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__RELABEL_CONFIGS_2__TARGET_LABEL", "target2")
+	c.InsertEnv("SCRAPE_CONFIGS_1__METRIC_RELABEL_CONFIGS_1__SOURCE_LABELS_1", "label1")
+	c.InsertEnv("SCRAPE_CONFIGS_1__METRIC_RELABEL_CONFIGS_1__SOURCE_LABELS_2", "label2")
+
+	c.InsertEnv("SCRAPE_CONFIGS_2__JOB_NAME", "jobname2")
+	c.InsertEnv("SCRAPE_CONFIGS_2__DNS_SD_CONFIGS_1__NAMES_1", "hello2")
+	c.InsertEnv("SCRAPE_CONFIGS_2__DNS_SD_CONFIGS_1__TYPE", "A")
+	c.InsertEnv("SCRAPE_CONFIGS_2__DNS_SD_CONFIGS_1__PORT", "1233")
+
+	s.Require().Len(c.ScrapeConfigs, 2)
+	s1 := c.ScrapeConfigs[0]
+	s.Equal("jobname1", s1.JobName)
+	s.Equal(true, s1.HonorLabels)
+
+	s.Require().Len(s1.Params["key"], 2)
+	s.Equal("first", s1.Params["key"][0])
+	s.Equal("second", s1.Params["key"][1])
+	s.Equal("13s", s1.ScrapeInterval)
+	s.Equal("17s", s1.ScrapeTimeout)
+	s.Equal("/metrics1", s1.MetricsPath)
+	s.Equal("http", s1.Scheme)
+	s.Equal(uint(10), s1.SampleLimit)
+
+	s.Require().Len(s1.ServiceDiscoveryConfig.DNSSDConfigs, 1)
+	s1dnsc := s1.ServiceDiscoveryConfig.DNSSDConfigs[0]
+	s.Equal("hello", s1dnsc.Names[0])
+	s.Equal("18s", s1dnsc.RefreshInterval)
+	s.Equal("A", s1dnsc.Type)
+	s.Equal(123, s1dnsc.Port)
+
+	s1hcc := s1.HTTPClientConfig
+	s.Equal("username1", s1hcc.BasicAuth.Username)
+	s.Equal("password1", s1hcc.BasicAuth.Password)
+	s.Equal("btoken", s1hcc.BearerToken)
+	s.Equal("localhost1", s1hcc.ProxyURL)
+	s.Equal("cafile", s1hcc.TLSConfig.CAFile)
+	s.Equal("certfile", s1hcc.TLSConfig.CertFile)
+	s.Equal("keyfile", s1hcc.TLSConfig.KeyFile)
+	s.Equal("servicename", s1hcc.TLSConfig.ServerName)
+	s.Equal(true, s1hcc.TLSConfig.InsecureSkipVerify)
+
+	s.Require().Len(s1.RelabelConfigs, 2)
+	s.Equal("target1", s1.RelabelConfigs[0].TargetLabel)
+	s.Equal("target2", s1.RelabelConfigs[1].TargetLabel)
+
+	s.Require().Len(s1.MetricRelabelConfigs, 1)
+	s1sl := s1.MetricRelabelConfigs[0].SourceLabels
+	s.Require().Len(s1sl, 2)
+	s.Equal("label1", s1sl[0])
+	s.Equal("label2", s1sl[1])
+
+	s2 := c.ScrapeConfigs[1]
+	s.Equal("jobname2", s2.JobName)
+
+	s2dnsc := s2.ServiceDiscoveryConfig.DNSSDConfigs
+	s.Require().Len(s2dnsc, 1)
+	s.Equal("hello2", s2dnsc[0].Names[0])
+	s.Equal("A", s2dnsc[0].Type)
+	s.Equal(1233, s2dnsc[0].Port)
 }
 
-func (s *ConfigTestSuite) Test_GetRemoteConfig_ReturnsRemoteReadRemoteWriteUrl() {
-	defer func() {
-		os.Unsetenv("REMOTE_READ_URL")
-		os.Unsetenv("REMOTE_WRITE_URL")
-	}()
-	os.Setenv("REMOTE_READ_URL", "http://acme.com/read")
-	os.Setenv("REMOTE_WRITE_URL", "http://acme.com/write")
-	expected := `remote_write:
-  - url: http://acme.com/write
-remote_read:
-  - url: http://acme.com/read`
-	actual := GetRemoteConfig()
+func (s *ConfigTestSuite) Test_RemoteReadConfigs() {
+	c := &Config{}
 
-	s.Equal(expected, actual)
+	c.InsertEnv("REMOTE_READ_1__URL", "localhost")
+	c.InsertEnv("REMOTE_READ_1__REMOTE_TIMEOUT", "10s")
+	c.InsertEnv("REMOTE_READ_1__READ_RECENT", "true")
+	c.InsertEnv("REMOTE_READ_1__BASIC_AUTH__USERNAME", "username")
+	c.InsertEnv("REMOTE_READ_1__BASIC_AUTH__PASSWORD", "password")
+	c.InsertEnv("REMOTE_READ_1__REQUIRED_MATCHERS", "key1=value1")
+	c.InsertEnv("REMOTE_READ_1__REQUIRED_MATCHERS", "key2=value2")
+
+	c.InsertEnv("REMOTE_READ_2__URL", "localhost2")
+
+	s.Require().Len(c.RemoteReadConfigs, 2)
+	rrc := c.RemoteReadConfigs[0]
+	s.Equal("localhost", rrc.URL)
+	s.Equal("10s", rrc.RemoteTimeout)
+	s.Equal("username", rrc.HTTPClientConfig.BasicAuth.Username)
+	s.Equal("password", rrc.HTTPClientConfig.BasicAuth.Password)
+	s.Equal("value1", rrc.RequiredMatchers["key1"])
+	s.Equal("value2", rrc.RequiredMatchers["key2"])
+
+	s.Equal("localhost2", c.RemoteReadConfigs[1].URL)
 }
 
-// GetGlobalConfig
+func (s *ConfigTestSuite) Test_RemoteWriteConfigs() {
+	c := &Config{}
 
-func (s *ConfigTestSuite) Test_GlobalConfig_ReturnsConfigWithData() {
-	scrapeIntervalOrig := os.Getenv("GLOBAL_SCRAPE_INTERVAL")
-	defer func() { os.Setenv("GLOBAL_SCRAPE_INTERVAL", scrapeIntervalOrig) }()
-	os.Setenv("GLOBAL_SCRAPE_INTERVAL", "123s")
-	expected := `global:
-  scrape_interval: 123s`
+	c.InsertEnv("REMOTE_WRITE_1__URL", "localhost")
+	c.InsertEnv("REMOTE_WRITE_1__REMOTE_TIMEOUT", "14s")
+	c.InsertEnv("REMOTE_WRITE_1__WRITE_RELABEL_CONFIGS_1__SOURCE_LABELS_1", "label1")
+	c.InsertEnv("REMOTE_WRITE_1__WRITE_RELABEL_CONFIGS_1__SOURCE_LABELS_2", "label2")
+	c.InsertEnv("REMOTE_WRITE_1__PROXY_URL", "proxy_url")
 
-	actual := GetGlobalConfig()
-	s.Equal(expected, actual)
+	c.InsertEnv("REMOTE_WRITE_2__URL", "localhost2")
+	c.InsertEnv("REMOTE_WRITE_2__REMOTE_TIMEOUT", "20s")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__CAPACITY", "10")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__MAX_SHARDS", "2")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__MAX_SAMPLES_PER_SEND", "4")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__BATCH_SEND_DEADLINE", "10s")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__MAX_RETRIES", "5")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__MIN_BACKOFF", "5s")
+	c.InsertEnv("REMOTE_WRITE_2__QUEUE_CONFIG__MAX_BACKOFF", "6s")
+
+	s.Require().Len(c.RemoteWriteConfigs, 2)
+	rcc1 := c.RemoteWriteConfigs[0]
+	s.Equal("localhost", rcc1.URL)
+	s.Equal("14s", rcc1.RemoteTimeout)
+
+	rcc1Wrc := rcc1.WriteRelabelConfigs
+	s.Require().Len(rcc1Wrc, 1)
+	s.Equal("label1", rcc1Wrc[0].SourceLabels[0])
+	s.Equal("label2", rcc1Wrc[0].SourceLabels[1])
+	s.Equal("proxy_url", rcc1.HTTPClientConfig.ProxyURL)
+
+	rcc2 := c.RemoteWriteConfigs[1]
+	s.Equal("localhost2", rcc2.URL)
+	s.Equal("20s", rcc2.RemoteTimeout)
+
+	rcc2qc := rcc2.QueueConfig
+	s.Equal(10, rcc2qc.Capacity)
+	s.Equal(2, rcc2qc.MaxShards)
+	s.Equal(4, rcc2qc.MaxSamplesPerSend)
+	s.Equal("10s", rcc2qc.BatchSendDeadline)
+	s.Equal(5, rcc2qc.MaxRetries)
+	s.Equal("5s", rcc2qc.MinBackoff)
+	s.Equal("6s", rcc2qc.MaxBackoff)
+
 }
 
-func (s *ConfigTestSuite) Test_GlobalConfig_AllowsNestedEntries() {
-	scrapeIntervalOrig := os.Getenv("GLOBAL_SCRAPE_INTERVAL")
-	defer func() {
-		os.Setenv("GLOBAL_SCRAPE_INTERVAL", scrapeIntervalOrig)
-		os.Unsetenv("GLOBAL_EXTERNAL_LABELS-CLUSTER")
-		os.Unsetenv("GLOBAL_EXTERNAL_LABELS-TYPE")
-	}()
-	os.Setenv("GLOBAL_SCRAPE_INTERVAL", "123s")
-	os.Setenv("GLOBAL_EXTERNAL_LABELS-CLUSTER", "swarm")
-	os.Setenv("GLOBAL_EXTERNAL_LABELS-TYPE", "production")
+func (s *ConfigTestSuite) Test_BackwardsEnvVars() {
+	c := &Config{}
+
+	c.InsertEnv("REMOTE_WRITE_URL", "http://acme.com/write")
+	c.InsertEnv("REMOTE_WRITE_REMOTE_TIMEOUT", "30s")
+	c.InsertEnv("REMOTE_READ_URL", "http://acme.com/read")
+	c.InsertEnv("REMOTE_READ_REMOTE_TIMEOUT", "30s")
+	c.InsertEnv("GLOBAL_SCRAPE_INTERVAL", "123s")
+	c.InsertEnv("GLOBAL_EXTERNAL_LABELS-CLUSTER", "swarm")
+	c.InsertEnv("GLOBAL_EXTERNAL_LABELS-TYPE", "production")
+
+	s.Equal("http://acme.com/write", c.RemoteWriteConfigs[0].URL)
+	s.Equal("30s", c.RemoteWriteConfigs[0].RemoteTimeout)
+	s.Equal("http://acme.com/read", c.RemoteReadConfigs[0].URL)
+	s.Equal("30s", c.RemoteReadConfigs[0].RemoteTimeout)
+	s.Equal("123s", c.GlobalConfig.ScrapeInterval)
+	s.Equal("swarm", c.GlobalConfig.ExternalLabels["cluster"])
+	s.Equal("production", c.GlobalConfig.ExternalLabels["type"])
+
+	cYAML, err := yaml.Marshal(c)
+	s.Require().NoError(err)
+
 	expected := `global:
   scrape_interval: 123s
   external_labels:
     cluster: swarm
-    type: production`
-	actual := ""
+    type: production
+remote_write:
+- url: http://acme.com/write
+  remote_timeout: 30s
+remote_read:
+- url: http://acme.com/read
+  remote_timeout: 30s
+`
 
-	// Because of ordering, the config is not always the same so we're repeating a failure for a few times.
-	for i := 0; i < 5; i++ {
-		actual = GetGlobalConfig()
-		if actual == expected {
-			return
-		}
-	}
-	s.Equal(expected, actual)
+	s.Equal(expected, string(cYAML))
+
 }
 
-// GetScrapeConfig
+func (s *ConfigTestSuite) Test_InsertAlertManagerURL() {
+	c := &Config{}
 
-func (s *ConfigTestSuite) Test_GetScrapeConfig_ReturnsConfigWithData() {
-	expected := `scrape_configs:
-  - job_name: "service-1"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.service-1"]
-        type: A
-        port: 1234
-  - job_name: "service-2"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.service-2"]
-        type: A
-        port: 5678
-  - job_name: "service-3"
-    metrics_path: /something
-    static_configs:
-      - targets:
-        - service-3:4321`
+	err := c.InsertAlertManagerURL("http://alert-manager:9093")
+	s.Require().NoError(err)
+
+	s.Require().Len(c.AlertingConfig.AlertmanagerConfigs, 1)
+	acc := c.AlertingConfig.AlertmanagerConfigs[0]
+	s.Equal("http", acc.Scheme)
+
+	s.Require().Len(acc.ServiceDiscoveryConfig.StaticConfigs, 1)
+	sc := acc.ServiceDiscoveryConfig.StaticConfigs[0]
+	s.Equal("alert-manager:9093", sc.Targets[0])
+
+	cYAML, err := yaml.Marshal(c)
+	s.Require().NoError(err)
+
+	expected := `alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - alert-manager:9093
+    scheme: http
+`
+
+	s.Equal(expected, string(cYAML))
+
+}
+
+func (s *ConfigTestSuite) Test_InsertScrape_ConfigWithData() {
+
 	scrapes := map[string]Scrape{
 		"service-1": {ServiceName: "service-1", ScrapePort: 1234},
 		"service-2": {ServiceName: "service-2", ScrapePort: 5678},
 		"service-3": {ServiceName: "service-3", ScrapePort: 4321, ScrapeType: "static_configs", MetricsPath: "/something"},
 	}
 
-	actual := GetScrapeConfig(scrapes)
+	c := &Config{}
+	c.InsertScrapes(scrapes)
+	s.Require().Len(c.ScrapeConfigs, 3)
 
-	s.Equal(expected, actual)
+	for _, sc := range c.ScrapeConfigs {
+		expectedC := scrapes[sc.JobName]
+		s.Equal(expectedC.ServiceName, sc.JobName)
+		if expectedC.ScrapeType != "static_configs" {
+			s.Equal(expectedC.ScrapePort, sc.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+			s.Equal("A", sc.ServiceDiscoveryConfig.DNSSDConfigs[0].Type)
+			s.Equal("/metrics", sc.MetricsPath)
+			s.Equal(fmt.Sprintf("tasks.%s", expectedC.ServiceName),
+				sc.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
+		} else {
+			s.Equal(expectedC.ServiceName, sc.JobName)
+			s.Equal(expectedC.MetricsPath, sc.MetricsPath)
+			s.Equal(fmt.Sprintf("%s:%d", expectedC.ServiceName, expectedC.ScrapePort),
+				sc.ServiceDiscoveryConfig.StaticConfigs[0].Targets[0])
+		}
+	}
 }
 
-func (s *ConfigTestSuite) Test_GetScrapeConfig_ReturnsConfigWithDataAndSecrets() {
+func (s *ConfigTestSuite) Test_InsertScrape_ConfigWithDataAndSecrets() {
 	fsOrig := FS
 	defer func() { FS = fsOrig }()
 	FS = afero.NewMemMapFs()
+
+	// Old style scrape secret file
 	job2 := `  - job_name: "service-2"
     metrics_path: /metrics
     dns_sd_configs:
       - names: ["tasks.service-2"]
         type: A
         port: 5678`
-	job3 := `  - job_name: "service-3"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.service-3"]
-        port: 9999`
-	expected := fmt.Sprintf(`scrape_configs:
-  - job_name: "service-1"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.service-1"]
-        type: A
-        port: 1234
-%s
-%s`,
-		job2,
-		job3,
-	)
+
+	// New style scrape secret file
+	job3 := `- job_name: "service-3"
+  metrics_path: /metrics
+  dns_sd_configs:
+    - names: ["tasks.service-3"]
+      port: 9999`
 	scrapes := map[string]Scrape{
 		"service-1": {ServiceName: "service-1", ScrapePort: 1234},
 	}
 	afero.WriteFile(FS, "/run/secrets/scrape_job2", []byte(job2), 0644)
 	afero.WriteFile(FS, "/run/secrets/scrape_job3", []byte(job3), 0644)
 
-	actual := GetScrapeConfig(scrapes)
+	c := &Config{}
+	c.InsertScrapes(scrapes)
+	c.InsertScrapesFromDir("/run/secrets")
 
-	s.Equal(expected, actual)
+	s.Require().Len(c.ScrapeConfigs, 3)
+
+	s1 := c.ScrapeConfigs[0]
+	s.Equal("service-1", s1.JobName)
+	s.Equal(1234, s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+	s.Equal("A", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Type)
+	s.Equal("/metrics", s1.MetricsPath)
+	s.Equal("tasks.service-1", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
+
+	s2 := c.ScrapeConfigs[1]
+	s.Equal("service-2", s2.JobName)
+	s.Equal(5678, s2.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+	s.Equal("A", s2.ServiceDiscoveryConfig.DNSSDConfigs[0].Type)
+	s.Equal("/metrics", s2.MetricsPath)
+	s.Equal("tasks.service-2", s2.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
+
+	s3 := c.ScrapeConfigs[2]
+	s.Equal("service-3", s3.JobName)
+	s.Equal(9999, s3.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+	s.Equal("/metrics", s3.MetricsPath)
+	s.Equal("tasks.service-3", s3.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
 }
 
-func (s *ConfigTestSuite) Test_GetScrapeConfig_ReturnsOnlySecretsWithScrapePrefix() {
+func (s *ConfigTestSuite) Test_InsertScrape_ConfigWithOnlySecrets_WithoutScrapePrefix() {
 	fsOrig := FS
 	defer func() { FS = fsOrig }()
 	FS = afero.NewMemMapFs()
-	job := `  - job_name: "my-service"
-    dns_sd_configs:
-      - names: ["tasks.my-service"]
-        type: A
-        port: 5678`
-	expected := fmt.Sprintf(`scrape_configs:
-%s`,
-		job,
-	)
+	job := `- job_name: "my-service"
+  dns_sd_configs:
+    - names: ["tasks.my-service"]
+      type: A
+      port: 5678`
+
 	scrapes := map[string]Scrape{}
 	afero.WriteFile(FS, "/run/secrets/scrape_job", []byte(job), 0644)
 	afero.WriteFile(FS, "/run/secrets/job_without_scrape_prefix", []byte("something silly"), 0644)
 
-	actual := GetScrapeConfig(scrapes)
+	c := &Config{}
+	c.InsertScrapes(scrapes)
+	c.InsertScrapesFromDir("/run/secrets")
 
-	s.Equal(expected, actual)
+	s.Require().Len(c.ScrapeConfigs, 1)
+
+	s1 := c.ScrapeConfigs[0]
+	s.Equal("my-service", s1.JobName)
+	s.Equal(5678, s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+	s.Equal("A", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Type)
+	s.Equal("tasks.my-service", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
 }
 
-func (s *ConfigTestSuite) Test_GetScrapeConfig_ReturnsConfigsFromCustomDirectory() {
+func (s *ConfigTestSuite) Test_InsertScrape_ConfiFromCustomDirectory() {
 	fsOrig := FS
 	defer func() { FS = fsOrig }()
 	FS = afero.NewMemMapFs()
-	defer func() { os.Unsetenv("CONFIGS_DIR") }()
-	os.Setenv("CONFIGS_DIR", "/tmp")
-	job := `  - job_name: "my-service"
-    dns_sd_configs:
-      - names: ["tasks.my-service"]
-        type: A
-        port: 5678`
-	expected := fmt.Sprintf(`scrape_configs:
-%s`,
-		job,
-	)
-	scrapes := map[string]Scrape{}
+	job := `- job_name: "my-service"
+  dns_sd_configs:
+    - names: ["tasks.my-service"]
+      type: A
+      port: 5678`
 	afero.WriteFile(FS, "/tmp/scrape_job", []byte(job), 0644)
 
-	actual := GetScrapeConfig(scrapes)
+	c := &Config{}
+	c.InsertScrapesFromDir("/tmp")
 
-	s.Equal(expected, actual)
+	s.Require().Len(c.ScrapeConfigs, 1)
+
+	s1 := c.ScrapeConfigs[0]
+	s.Equal("my-service", s1.JobName)
+	s.Equal(5678, s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Port)
+	s.Equal("A", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Type)
+	s.Equal("tasks.my-service", s1.ServiceDiscoveryConfig.DNSSDConfigs[0].Names[0])
+
 }
 
-func (s *ConfigTestSuite) Test_GetScrapeConfig_ReturnsEmptyString_WhenNoData() {
-	actual := GetScrapeConfig(map[string]Scrape{})
-
-	s.Empty(actual)
-}
-
-// WriteConfig
-
-func (s *ConfigTestSuite) Test_WriteConfig_WritesConfig() {
+func (s *ConfigTestSuite) Test_Writeconfig_WritesConfig() {
 	fsOrig := FS
 	defer func() {
 		FS = fsOrig
@@ -278,31 +510,29 @@ func (s *ConfigTestSuite) Test_WriteConfig_WritesConfig() {
 		"service-1": {ServiceName: "service-1", ScrapePort: 1234},
 		"service-2": {ServiceName: "service-2", ScrapePort: 5678},
 	}
-	gc := GetGlobalConfig()
-	sc := GetScrapeConfig(scrapes)
-	rc := GetRemoteConfig()
-	acm := GetAlertManagerConfig()
-	expected := fmt.Sprintf(`%s
-%s
-%s
-%s`,
-		gc,
-		sc,
-		rc,
-		acm,
-	)
-	println("000")
-	println(rc)
-	println("111")
+	alerts := map[string]Alert{}
 
-	WriteConfig(scrapes, map[string]Alert{})
+	c := Config{}
+	c.InsertEnv("REMOTE_WRITE_URL", "http://acme.com/write")
+	c.InsertEnv("REMOTE_READ_URL", "http://acme.com/read")
+	c.InsertScrapes(scrapes)
 
+	WriteConfig("/etc/prometheus/prometheus.yml", scrapes, alerts)
 	actual, _ := afero.ReadFile(FS, "/etc/prometheus/prometheus.yml")
-	s.Equal(expected, string(actual))
-	//	s.Fail(string(actual))
+
+	actualConfig := Config{}
+	err := yaml.Unmarshal(actual, &actualConfig)
+	s.Require().NoError(err)
+
+	s.Equal(c.RemoteReadConfigs[0].URL, actualConfig.RemoteReadConfigs[0].URL)
+	s.Equal(c.RemoteWriteConfigs[0].URL, actualConfig.RemoteWriteConfigs[0].URL)
+
+	// Order of scrapes can be different
+	s.Contains(actualConfig.ScrapeConfigs, c.ScrapeConfigs[0])
+	s.Contains(actualConfig.ScrapeConfigs, c.ScrapeConfigs[1])
 }
 
-func (s *ConfigTestSuite) Test_WriteConfig_WritesAlerts() {
+func (s *ConfigTestSuite) Test_WriteConfig_WriteAlerts() {
 	fsOrig := FS
 	defer func() { FS = fsOrig }()
 	FS = afero.NewMemMapFs()
@@ -313,18 +543,16 @@ func (s *ConfigTestSuite) Test_WriteConfig_WritesAlerts() {
 		AlertNameFormatted: "myservicealertname",
 		AlertIf:            "a>b",
 	}
-	gc := GetGlobalConfig()
-	acm := GetAlertManagerConfig()
-	expectedConfig := fmt.Sprintf(`%s
-rule_files:
-  - 'alert.rules'
-%s`, gc, acm)
+
+	c := &Config{}
+	c.RuleFiles = []string{"alert.rules"}
+	cYAML, _ := yaml.Marshal(c)
 	expectedAlerts := GetAlertConfig(alerts)
 
-	WriteConfig(map[string]Scrape{}, alerts)
+	WriteConfig("/etc/prometheus/prometheus.yml", map[string]Scrape{}, alerts)
 
 	actualConfig, _ := afero.ReadFile(FS, "/etc/prometheus/prometheus.yml")
-	s.Equal(expectedConfig, string(actualConfig))
+	s.Equal(cYAML, actualConfig)
 	actualAlerts, _ := afero.ReadFile(FS, "/etc/prometheus/alert.rules")
 	s.Equal(expectedAlerts, string(actualAlerts))
 }

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -1,5 +1,207 @@
 package prometheus
 
+// ScrapeConfig configures a scraping unit for Prometheus.
+type ScrapeConfig struct {
+	// The job name to which the job label is set by default.
+	JobName string `yaml:"job_name"`
+	// Indicator whether the scraped metrics should remain unmodified.
+	HonorLabels bool `yaml:"honor_labels,omitempty"`
+	// A set of query parameters with which the target is scraped.
+	Params map[string][]string `yaml:"params,omitempty"`
+	// How frequently to scrape the targets of this scrape config.
+	ScrapeInterval string `yaml:"scrape_interval,omitempty"`
+	// The timeout for scraping targets of this config.
+	ScrapeTimeout string `yaml:"scrape_timeout,omitempty"`
+	// The HTTP resource path on which to fetch metrics from targets.
+	MetricsPath string `yaml:"metrics_path,omitempty"`
+	// The URL scheme with which to fetch metrics from targets.
+	Scheme string `yaml:"scheme,omitempty"`
+	// More than this many samples post metric-relabelling will cause the scrape to fail.
+	SampleLimit uint `yaml:"sample_limit,omitempty"`
+
+	ServiceDiscoveryConfig ServiceDiscoveryConfig `yaml:",inline"`
+	HTTPClientConfig       HTTPClientConfig       `yaml:",inline"`
+
+	// List of target relabel configurations.
+	RelabelConfigs []*RelabelConfig `yaml:"relabel_configs,omitempty"`
+	// List of metric relabel configurations.
+	MetricRelabelConfigs []*RelabelConfig `yaml:"metric_relabel_configs,omitempty"`
+}
+
+// RemoteReadConfig is the configuration for reading from remote storage.
+type RemoteReadConfig struct {
+	URL           string `yaml:"url"`
+	RemoteTimeout string `yaml:"remote_timeout,omitempty"`
+	ReadRecent    bool   `yaml:"read_recent,omitempty"`
+
+	HTTPClientConfig HTTPClientConfig `yaml:",inline"`
+
+	// RequiredMatchers is an optional list of equality matchers which have to
+	// be present in a selector to query the remote read endpoint.
+	RequiredMatchers map[string]string `yaml:"required_matchers,omitempty"`
+}
+
+// QueueConfig is the configuration for the queue used to write to remote
+// storage.
+type QueueConfig struct {
+	// Number of samples to buffer per shard before we start dropping them.
+	Capacity int `yaml:"capacity,omitempty"`
+
+	// Max number of shards, i.e. amount of concurrency.
+	MaxShards int `yaml:"max_shards,omitempty"`
+
+	// Maximum number of samples per send.
+	MaxSamplesPerSend int `yaml:"max_samples_per_send,omitempty"`
+
+	// Maximum time sample will wait in buffer.
+	BatchSendDeadline string `yaml:"batch_send_deadline,omitempty"`
+
+	// Max number of times to retry a batch on recoverable errors.
+	MaxRetries int `yaml:"max_retries,omitempty"`
+
+	// On recoverable errors, backoff exponentially.
+	MinBackoff string `yaml:"min_backoff,omitempty"`
+	MaxBackoff string `yaml:"max_backoff,omitempty"`
+}
+
+// RemoteWriteConfig is the configuration for writing to remote storage.
+type RemoteWriteConfig struct {
+	URL                 string           `yaml:"url"`
+	RemoteTimeout       string           `yaml:"remote_timeout,omitempty"`
+	WriteRelabelConfigs []*RelabelConfig `yaml:"write_relabel_configs,omitempty"`
+
+	HTTPClientConfig HTTPClientConfig `yaml:",inline"`
+	QueueConfig      QueueConfig      `yaml:"queue_config,omitempty"`
+}
+
+// TargetGroup is a set of targets with a common label set(production , test, staging etc.).
+type TargetGroup struct {
+	// Targets is a list of targets identified by a label set. Each target is
+	// uniquely identifiable in the group by its address label.
+	Targets []string `yaml:"targets,omitempty"`
+	// Labels is a set of labels that is common across all targets in the group.
+	Labels map[string]string `yaml:"labels,omitempty"`
+
+	// Source is an identifier that describes a group of targets.
+	Source string `yaml:"source,omitempty"`
+}
+
+// DNSSDConfig is the configuration for DNS based service discovery.
+type DNSSDConfig struct {
+	Names           []string `yaml:"names"`
+	RefreshInterval string   `yaml:"refresh_interval,omitempty"`
+	Type            string   `yaml:"type"`
+	Port            int      `yaml:"port"` // Ignored for SRV records
+}
+
+// ServiceDiscoveryConfig configures lists of different service discovery mechanisms.
+type ServiceDiscoveryConfig struct {
+	// List of labeled target groups for this job.
+	StaticConfigs []*TargetGroup `yaml:"static_configs,omitempty"`
+	// List of DNS service discovery configurations.
+	DNSSDConfigs []*DNSSDConfig `yaml:"dns_sd_configs,omitempty"`
+}
+
+// BasicAuth contains basic HTTP authentication credentials.
+type BasicAuth struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+// TLSConfig configures the options for TLS connections.
+type TLSConfig struct {
+	// The CA cert to use for the targets.
+	CAFile string `yaml:"ca_file,omitempty"`
+	// The client cert file for the targets.
+	CertFile string `yaml:"cert_file,omitempty"`
+	// The client key file for the targets.
+	KeyFile string `yaml:"key_file,omitempty"`
+	// Used to verify the hostname for the targets.
+	ServerName string `yaml:"server_name,omitempty"`
+	// Disable target certificate validation.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
+}
+
+// HTTPClientConfig configures an HTTP client.
+type HTTPClientConfig struct {
+	// The HTTP basic authentication credentials for the targets.
+	BasicAuth *BasicAuth `yaml:"basic_auth,omitempty"`
+	// The bearer token for the targets.
+	BearerToken string `yaml:"bearer_token,omitempty"`
+	// The bearer token file for the targets.
+	BearerTokenFile string `yaml:"bearer_token_file,omitempty"`
+	// HTTP proxy server to use to connect to the targets.
+	ProxyURL string `yaml:"proxy_url,omitempty"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
+}
+
+// AlertmanagerConfig configures how Alertmanagers can be discovered and communicated with.
+type AlertmanagerConfig struct {
+	ServiceDiscoveryConfig ServiceDiscoveryConfig `yaml:",inline"`
+	HTTPClientConfig       HTTPClientConfig       `yaml:",inline"`
+
+	// The URL scheme to use when talking to Alertmanagers.
+	Scheme string `yaml:"scheme,omitempty"`
+	// Path prefix to add in front of the push endpoint path.
+	PathPrefix string `yaml:"path_prefix,omitempty"`
+	// The timeout used when sending alerts.
+	Timeout string `yaml:"timeout,omitempty"`
+
+	// List of Alertmanager relabel configurations.
+	RelabelConfigs []*RelabelConfig `yaml:"relabel_configs,omitempty"`
+}
+
+// RelabelConfig is the configuration for relabeling of target label sets.
+type RelabelConfig struct {
+	// A list of labels from which values are taken and concatenated
+	// with the configured separator in order.
+	SourceLabels []string `yaml:"source_labels,flow,omitempty"`
+	// Separator is the string between concatenated values from the source labels.
+	Separator string `yaml:"separator,omitempty"`
+	// Regex against which the concatenation is matched.
+	Regex string `yaml:"regex,omitempty"`
+	// Modulus to take of the hash of concatenated values from the source labels.
+	Modulus uint64 `yaml:"modulus,omitempty"`
+	// TargetLabel is the label to which the resulting string is written in a replacement.
+	// Regexp interpolation is allowed for the replace action.
+	TargetLabel string `yaml:"target_label,omitempty"`
+	// Replacement is the regex replacement pattern to be used.
+	Replacement string `yaml:"replacement,omitempty"`
+	// Action is the action to be performed for the relabeling.
+	Action string `yaml:"action,omitempty"`
+}
+
+// AlertingConfig configures alerting and alertmanager related configs.
+type AlertingConfig struct {
+	AlertRelabelConfigs []*RelabelConfig      `yaml:"alert_relabel_configs,omitempty"`
+	AlertmanagerConfigs []*AlertmanagerConfig `yaml:"alertmanagers,omitempty"`
+}
+
+// GlobalConfig configures values that are used across other configuration
+// objects.
+type GlobalConfig struct {
+	// How frequently to scrape targets by default.
+	ScrapeInterval string `yaml:"scrape_interval,omitempty"`
+	// The default timeout when scraping targets.
+	ScrapeTimeout string `yaml:"scrape_timeout,omitempty"`
+	// How frequently to evaluate rules by default.
+	EvaluationInterval string `yaml:"evaluation_interval,omitempty"`
+	// The labels to add to any timeseries that this Prometheus instance scrapes.
+	ExternalLabels map[string]string `yaml:"external_labels,omitempty"`
+}
+
+// Config is the top-level configuration for Prometheus's config files.
+type Config struct {
+	GlobalConfig   GlobalConfig    `yaml:"global,omitempty"`
+	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
+	RuleFiles      []string        `yaml:"rule_files,omitempty"`
+	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+
+	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
+	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
+}
+
 // Alert defines data used to create alert configuration snippet
 type Alert struct {
 	AlertAnnotations   map[string]string `json:"alertAnnotations,omitempty"`

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -100,10 +100,11 @@ func (s *ServerTestSuite) Test_Execute_WritesConfig() {
   scrape_interval: 5s
 alerting:
   alertmanagers:
-  - scheme: http
-    static_configs:
+  - static_configs:
     - targets:
-      - alert-manager:9093`
+      - alert-manager:9093
+    scheme: http
+`
 	fsOrig := prometheus.FS
 	defer func() { prometheus.FS = fsOrig }()
 	prometheus.FS = afero.NewMemMapFs()
@@ -554,21 +555,23 @@ func (s *ServerTestSuite) Test_ReconfigureHandler_ReturnsJson() {
 func (s *ServerTestSuite) Test_ReconfigureHandler_CallsWriteConfig() {
 	expected := `global:
   scrape_interval: 5s
-scrape_configs:
-  - job_name: "my-service"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.my-service"]
-        type: A
-        port: 1234
-rule_files:
-  - 'alert.rules'
 alerting:
   alertmanagers:
-  - scheme: http
-    static_configs:
+  - static_configs:
     - targets:
-      - alert-manager:9093`
+      - alert-manager:9093
+    scheme: http
+rule_files:
+- alert.rules
+scrape_configs:
+- job_name: my-service
+  metrics_path: /metrics
+  dns_sd_configs:
+  - names:
+    - tasks.my-service
+    type: A
+    port: 1234
+`
 	rwMock := ResponseWriterMock{}
 	addr := "/v1/docker-flow-monitor?serviceName=my-service&scrapePort=1234&alertName=my-alert&alertIf=my-if&alertFor=my-for"
 	req, _ := http.NewRequest("GET", addr, nil)
@@ -757,19 +760,21 @@ func (s *ServerTestSuite) Test_RemoveHandler_ReturnsJson() {
 func (s *ServerTestSuite) Test_RemoveHandler_CallsWriteConfig() {
 	expectedAfterGet := `global:
   scrape_interval: 5s
-scrape_configs:
-  - job_name: "my-service"
-    metrics_path: /metrics
-    dns_sd_configs:
-      - names: ["tasks.my-service"]
-        type: A
-        port: 1234
 alerting:
   alertmanagers:
-  - scheme: http
-    static_configs:
+  - static_configs:
     - targets:
-      - alert-manager:9093`
+      - alert-manager:9093
+    scheme: http
+scrape_configs:
+- job_name: my-service
+  metrics_path: /metrics
+  dns_sd_configs:
+  - names:
+    - tasks.my-service
+    type: A
+    port: 1234
+`
 	rwMock := ResponseWriterMock{}
 	addr := "/v1/docker-flow-monitor?serviceName=my-service&scrapePort=1234"
 	req, _ := http.NewRequest("GET", addr, nil)
@@ -787,10 +792,11 @@ alerting:
   scrape_interval: 5s
 alerting:
   alertmanagers:
-  - scheme: http
-    static_configs:
+  - static_configs:
     - targets:
-      - alert-manager:9093`
+      - alert-manager:9093
+    scheme: http
+`
 	addr = "/v1/docker-flow-monitor?serviceName=my-service"
 	req, _ = http.NewRequest("DELETE", addr, nil)
 


### PR DESCRIPTION
Closes #17 

1. Backwards compatible with the previous method to add global, remote_write, remote_read and scraping configurations.
2. Uses YAML tags with environmental variables to figure out how to construct the Config struct.
3. Documentation on how to use the new syntax. (Includes global, remote_write, and remote_read)