### PR TITLE
Adds compound alerts

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,6 +62,12 @@ Please visit [Alerting Overview](https://prometheus.io/docs/alerting/overview/) 
 !!! note
     I hope that the number of shortcuts will grow with time thanks to community contributions. Please create [an issue](https://github.com/vfarcic/docker-flow-monitor/issues) with the `alertIf` statement and the suggested shortcut and I'll add it to the code as soon as possible.
 
+### AlertIf Logical Operators
+
+The logical operators `and`, `unless`, and `or` can be used in combinations with AlertIf Parameter Shortcuts. For example, to create an alert that triggers when response time is low unless response time is high, set `alertIf=@resp_time_below:0.025,5m,0.75_unless_@resp_time_above:0.1,5m,0.99`. This alert prevents `@resp_time_below` from triggering while `@resp_time_above` is triggering. The `summary` annotation for this alert will be merged with the `and` operator: "Response time of the service my-service is below 0.025 unless Response time of the service my-service is above 0.1". When using logical operators, there are no default alert labels. The alert labels will have to be manually set by using the `alertLabels` query parameter.
+
+ More information on the logical operators can be found on Prometheus's querying [documentation](https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators).
+
 ## Remove
 
 !!! tip

--- a/server/server.go
+++ b/server/server.go
@@ -324,40 +324,136 @@ var alertIfShortcutData = map[string]alertIfShortcut{
 
 func (s *serve) formatAlert(alert *prometheus.Alert) {
 	alert.AlertNameFormatted = s.getNameFormatted(fmt.Sprintf("%s_%s", alert.ServiceName, alert.AlertName))
-	if strings.HasPrefix(alert.AlertIf, "@") {
+	if !strings.HasPrefix(alert.AlertIf, "@") {
+		return
+	}
+
+	_, bOp, _ := splitCompoundOp(alert.AlertIf)
+	if len(bOp) > 0 {
+		formatCompoundAlert(alert)
+	} else {
+		formatSingleAlert(alert)
+	}
+
+}
+
+func formatSingleAlert(alert *prometheus.Alert) {
+
+	value := ""
+	alertSplit := strings.Split(alert.AlertIf, ":")
+	shortcut := alertSplit[0]
+
+	if len(alertSplit) > 1 {
+		value = alertSplit[1]
+	}
+
+	data, ok := alertIfShortcutData[shortcut]
+	if !ok {
+		return
+	}
+
+	alert.AlertIf = replaceTags(data.expanded, alert, value)
+
+	if alert.AlertAnnotations == nil {
+		alert.AlertAnnotations = map[string]string{}
+	}
+	for k, v := range data.annotations {
+		if _, ok := alert.AlertAnnotations[k]; !ok {
+			alert.AlertAnnotations[k] = replaceTags(v, alert, value)
+		}
+	}
+
+	if alert.AlertLabels == nil {
+		alert.AlertLabels = map[string]string{}
+	}
+	for k, v := range data.labels {
+		if _, ok := alert.AlertLabels[k]; !ok {
+			alert.AlertLabels[k] = replaceTags(v, alert, value)
+		}
+	}
+}
+
+func formatCompoundAlert(alert *prometheus.Alert) {
+	alertIfStr := alert.AlertIf
+	alertAnnotations := map[string]string{}
+	immutableAnnotations := map[string]struct{}{}
+
+	// copy alert annotations and alert labels
+	if alert.AlertAnnotations != nil {
+		for k := range alert.AlertAnnotations {
+			immutableAnnotations[k] = struct{}{}
+		}
+	}
+
+	var alertIfFormattedBuffer bytes.Buffer
+
+	currentAlert, bOp, alertIfStr := splitCompoundOp(alertIfStr)
+
+	for len(currentAlert) > 0 {
 		value := ""
-		alertSplit := strings.Split(alert.AlertIf, ":")
+		alertSplit := strings.Split(currentAlert, ":")
 		shortcut := alertSplit[0]
 
 		if len(alertSplit) > 1 {
 			value = alertSplit[1]
 		}
-
 		data, ok := alertIfShortcutData[shortcut]
 		if !ok {
 			return
 		}
 
-		alert.AlertIf = replaceTags(data.expanded, alert, value)
-
-		if alert.AlertAnnotations == nil {
-			alert.AlertAnnotations = map[string]string{}
+		alertIfFormattedBuffer.WriteString(replaceTags(data.expanded, alert, value))
+		if len(bOp) > 0 {
+			alertIfFormattedBuffer.WriteString(fmt.Sprintf(" %s ", bOp))
 		}
+
 		for k, v := range data.annotations {
-			if _, ok := alert.AlertAnnotations[k]; !ok {
-				alert.AlertAnnotations[k] = replaceTags(v, alert, value)
+			if _, ok := immutableAnnotations[k]; ok {
+				continue
+			}
+			alertAnnotations[k] += replaceTags(v, alert, value)
+			if len(bOp) > 0 {
+				alertAnnotations[k] += fmt.Sprintf(" %s ", bOp)
 			}
 		}
+		currentAlert, bOp, alertIfStr = splitCompoundOp(alertIfStr)
+	}
 
-		if alert.AlertLabels == nil {
-			alert.AlertLabels = map[string]string{}
+	alert.AlertIf = alertIfFormattedBuffer.String()
+
+	if alert.AlertAnnotations == nil {
+		alert.AlertAnnotations = map[string]string{}
+	}
+
+	for k, v := range alertAnnotations {
+		if _, ok := immutableAnnotations[k]; ok {
+			continue
 		}
-		for k, v := range data.labels {
-			if _, ok := alert.AlertLabels[k]; !ok {
-				alert.AlertLabels[k] = replaceTags(v, alert, value)
-			}
+		alert.AlertAnnotations[k] = v
+	}
+
+}
+
+// splitCompoundOp find splits string into three pieces if it includes _unless_,
+// _and_, or _or_. For example, hello_and_world_or_earth will return [hello, and, world_or_earth]
+func splitCompoundOp(s string) (string, string, string) {
+	binaryOps := []string{"unless", "and", "or"}
+
+	minIdx := len(s)
+	minOp := ""
+	for _, bOp := range binaryOps {
+		idx := strings.Index(s, fmt.Sprintf("_%s_", bOp))
+		if idx != -1 && idx < minIdx {
+			minIdx = idx
+			minOp = bOp
 		}
 	}
+
+	if len(minOp) > 0 {
+		return s[:minIdx], minOp, s[minIdx+len(minOp)+2:]
+	}
+	return s, "", ""
+
 }
 
 func replaceTags(tag string, alert *prometheus.Alert, value string) string {


### PR DESCRIPTION
 Alertif shortcuts can now be combined with `_and_`, `_or_` and `_unless_`. For example: 

```
@resp_time_below:0.025,5m,0.75_unless_@resp_time_above:0.1,5m,0.99
```

This alert can prevents @resp_time_below from trigger when @resp_time_above is triggering. 

1. Using compound alerts does not automatically add any alert labels. 

2. Any default annotations will be combined using the operator. For the above example, the summary annotation will become: **Response time of the service my-service is below 0.025 unless Response time of the service my-service is above 0.1**.