### PR TITLE
ENH: Allows multiple urls through ARG_ALERTMANAGER_URL

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,24 @@ ARG_WEB_CONSOLE_LIBRARIES=/usr/share/prometheus/console_libraries
 ARG_WEB_CONSOLE_TEMPLATES=/usr/share/prometheus/consoles
 ```
 
+The `ARG_ALERTMANAGER_URL` environment variable accepts a comma separated list of alertmanagers:
+
+```
+ARG_ALERTMANAGER_URL=http://alert-manager:9093,http://alert-manager2:9093
+```
+
+These urls are configured in Prometheus's config file as `static_configs`:
+
+```yaml
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - alert-manager:9093
+      - alert-manager2:9093
+    scheme: http
+```
+
 ## Configuration
 
 Environment variables prefixed with `GLOBAL__`, `ALERTING__`, `SCRAPE_CONFIGS__`, `REMOTE_WRITE__`, and `REMOTE_READ__` are used to configure Prometheus.

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -338,8 +338,7 @@ remote_read:
 func (s *ConfigTestSuite) Test_InsertAlertManagerURL() {
 	c := &Config{}
 
-	err := c.InsertAlertManagerURL("http://alert-manager:9093")
-	s.Require().NoError(err)
+	c.InsertAlertManagerURL("http://alert-manager:9093")
 
 	s.Require().Len(c.AlertingConfig.AlertmanagerConfigs, 1)
 	acc := c.AlertingConfig.AlertmanagerConfigs[0]
@@ -357,6 +356,35 @@ func (s *ConfigTestSuite) Test_InsertAlertManagerURL() {
   - static_configs:
     - targets:
       - alert-manager:9093
+    scheme: http
+`
+
+	s.Equal(expected, string(cYAML))
+
+}
+
+func (s *ConfigTestSuite) Test_InsertAlertManagerURL_TwoUrls() {
+	c := &Config{}
+
+	c.InsertAlertManagerURL("http://alert-manager:9093,http://alert-manager2:9093")
+
+	s.Require().Len(c.AlertingConfig.AlertmanagerConfigs, 1)
+	acc := c.AlertingConfig.AlertmanagerConfigs[0]
+	s.Equal("http", acc.Scheme)
+
+	s.Require().Len(acc.ServiceDiscoveryConfig.StaticConfigs, 1)
+	sc := acc.ServiceDiscoveryConfig.StaticConfigs[0]
+	s.Equal("alert-manager:9093", sc.Targets[0])
+
+	cYAML, err := yaml.Marshal(c)
+	s.Require().NoError(err)
+
+	expected := `alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - alert-manager:9093
+      - alert-manager2:9093
     scheme: http
 `
 


### PR DESCRIPTION
https://github.com/vfarcic/docker-flow-monitor/issues/46

Adds comma separated urls to be set through `ARG_ALERTMANAGER_URL`.